### PR TITLE
Optimize

### DIFF
--- a/templates/pgrest/config.yml
+++ b/templates/pgrest/config.yml
@@ -10,10 +10,6 @@ data:
     db-schemas = "public"
     openapi-server-proxy-uri = "https://{{ .Values.pgrest.ingress.host }}"
     
-    db-max-rows=100
-
-    db-pool=30
-
     openapi-mode = "ignore-privileges"
 
     # The database role to use when no client authentication is provided.
@@ -31,3 +27,5 @@ data:
     # log level
     log-level = "{{ .Values.pgrest.loglevel }}"
 
+    db-pool = {{ .Values.pgrest.dbPool }}
+    db-max-rows = {{ .Values.pgrest.dbMaxRows }}

--- a/templates/pgrest/hpa.yaml
+++ b/templates/pgrest/hpa.yaml
@@ -1,0 +1,22 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  creationTimestamp: null
+  name: {{ include "data-tool.fullname" . }}
+  labels:
+    {{- include "data-tool.labels" . | nindent 4 }}
+    app: dso-data-tool
+spec:
+  minReplicas: {{ .Values.pgrest.hpa.replicaCountMin | default 1 }}
+  maxReplicas: {{ .Values.pgrest.hpa.replicaCountMax | default 7 }}
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "data-tool.fullname" . }}
+  metrics:
+  - type: Resource
+    resource:
+      name: memory
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.pgrest.hpa.averageMemory | default 80 }}

--- a/values.yaml
+++ b/values.yaml
@@ -27,12 +27,9 @@ importer:
 pgrest:
   jwtSecret: "" # secret jwt (A générer et renseigner)
   anonRole: anon
-<<<<<<< HEAD
   replicaCount: 2
-=======
   dbPool: 30
   dbMaxRows: 100
->>>>>>> 28458d4 (optimize)
   service:
     port: 3000
   ingress:

--- a/values.yaml
+++ b/values.yaml
@@ -27,7 +27,12 @@ importer:
 pgrest:
   jwtSecret: "" # secret jwt (A générer et renseigner)
   anonRole: anon
+<<<<<<< HEAD
   replicaCount: 2
+=======
+  dbPool: 30
+  dbMaxRows: 100
+>>>>>>> 28458d4 (optimize)
   service:
     port: 3000
   ingress:
@@ -44,6 +49,10 @@ pgrest:
     repository: bitnami/postgrest
     tag: 11.2.2-debian-11-r0
     pullPolicy: IfNotPresent
+  hpa:
+    replicaCountMin: 3
+    replicaCountMax: 7
+    averageMemory: 80
 
 adminer:
   enabled: false
@@ -157,6 +166,8 @@ postgresql:
       enabled: false
     podSecurityContext:
       enabled: false
+    extendedConfiguration: |
+      max_connections = 210
 
 swagger:
   image:


### PR DESCRIPTION
1ère mouture pour de l'optimisation:

Tests de perf effectué:
1000 utilisateurs (pendant 1min) qui effectuent une requête vers la page `identites?nom_officiel=eq.${encodeURIComponent(random_name)}` puis un sleep de 1s

Résultat:
```
     checks.....................: 99.93% ✓ 17588      ✗ 11    
     counter_status.............: 17559  219.69783/s
     data_received..............: 12 MB  152 kB/s
     data_sent..................: 6.2 MB 77 kB/s
     http_req_blocked...........: avg=6.23ms  min=1.01µs  med=4.89µs  max=3.17s    p(90)=9.07µs   p(95)=51.53ms 
     http_req_connecting........: avg=3.08ms  min=0s      med=0s      max=3.14s    p(90)=0s       p(95)=22.4ms  
     http_req_duration..........: avg=3.03s   min=43.72ms med=1.29s   max=27.92s   p(90)=9.32s    p(95)=13.98s  
     http_req_failed............: 0.17%  ✓ 31         ✗ 17548 
     http_req_receiving.........: avg=79.42µs min=13.2µs  med=62.86µs max=1.53ms   p(90)=149.36µs p(95)=180.93µs
     http_req_sending...........: avg=28.99µs min=5.28µs  med=20.52µs max=635.56µs p(90)=54.59µs  p(95)=87.52µs 
     http_req_tls_handshaking...: avg=2.95ms  min=0s      med=0s      max=1.86s    p(90)=0s       p(95)=26.43ms 
     http_req_waiting...........: avg=3.03s   min=43.53ms med=1.29s   max=27.92s   p(90)=9.32s    p(95)=13.98s  
     http_reqs..................: 17579  219.948069/s
     iteration_duration.........: avg=4.03s   min=1.04s   med=2.29s   max=28.93s   p(90)=10.33s   p(95)=14.98s  
     iterations.................: 17579  219.948069/s
     status_error...............: 11     0.137632/s
     vus........................: 339    min=113      max=1006
     vus_max....................: 1020   min=1020     max=1020
```

Les 11 erreurs concernent un `Timed out acquiring connection from connection pool`