### PR TITLE
Compare with accent

### DIFF
--- a/templates/pgrest/configInit.yml
+++ b/templates/pgrest/configInit.yml
@@ -33,11 +33,11 @@ data:
      (
       num_ordre character varying(17) COLLATE pg_catalog."default",
       ind_chg character varying(2) COLLATE pg_catalog."default",
-      nom_officiel character varying(300) COLLATE ignore_accents_case_insensitive,
-      prenoms_officiels character varying(300) COLLATE ignore_accents_case_insensitive,
+      nom_officiel character varying(300) COLLATE pg_catalog."default",
+      prenoms_officiels character varying(300) COLLATE pg_catalog."default",
       date_officiel character varying(10) COLLATE pg_catalog."default",
-      anc_nom character varying(300) COLLATE ignore_accents_case_insensitive,
-      anc_prenoms character varying(300) COLLATE ignore_accents_case_insensitive,
+      anc_nom character varying(300) COLLATE pg_catalog."default",
+      anc_prenoms character varying(300) COLLATE pg_catalog."default",
       anc_date character varying(10) COLLATE pg_catalog."default",
       nai_date character varying(10) COLLATE pg_catalog."default",
       nai_lieu character varying(5) COLLATE pg_catalog."default",
@@ -63,7 +63,7 @@ data:
 
     CREATE OR REPLACE FUNCTION prenoms_officiels_q(identites)
     RETURNS text AS $$
-      SELECT (regexp_replace(UPPER(f_unaccent(($1.prenoms_officiels))), '['',-]', ' ', 'g'));
+      SELECT (regexp_replace(($1.prenoms_officiels), '['',-]', ' ', 'g')) COLLATE ignore_accents_case_insensitive;
     $$ LANGUAGE SQL;
 
     CREATE OR REPLACE FUNCTION anc_nom_q(identites)

--- a/templates/pgrest/configInit.yml
+++ b/templates/pgrest/configInit.yml
@@ -14,6 +14,8 @@ data:
     DROP TABLE public.identites cascade;
     CREATE EXTENSION IF NOT EXISTS "unaccent";
 
+    CREATE COLLATION ignore_accents_case_insensitive (provider = icu, locale = 'und-u-ks-level1', deterministic = false);
+
     DROP EVENT TRIGGER pgrst_watch;
     CREATE OR REPLACE FUNCTION pgrst_watch() RETURNS event_trigger
       LANGUAGE plpgsql
@@ -31,11 +33,11 @@ data:
      (
       num_ordre character varying(17) COLLATE pg_catalog."default",
       ind_chg character varying(2) COLLATE pg_catalog."default",
-      nom_officiel character varying(300) COLLATE pg_catalog."default",
-      prenoms_officiels character varying(300) COLLATE pg_catalog."default",
+      nom_officiel character varying(300) COLLATE ignore_accents_case_insensitive,
+      prenoms_officiels character varying(300) COLLATE ignore_accents_case_insensitive,
       date_officiel character varying(10) COLLATE pg_catalog."default",
-      anc_nom character varying(300) COLLATE pg_catalog."default",
-      anc_prenoms character varying(300) COLLATE pg_catalog."default",
+      anc_nom character varying(300) COLLATE ignore_accents_case_insensitive,
+      anc_prenoms character varying(300) COLLATE ignore_accents_case_insensitive,
       anc_date character varying(10) COLLATE pg_catalog."default",
       nai_date character varying(10) COLLATE pg_catalog."default",
       nai_lieu character varying(5) COLLATE pg_catalog."default",

--- a/templates/pgrest/configInit.yml
+++ b/templates/pgrest/configInit.yml
@@ -14,8 +14,6 @@ data:
     DROP TABLE public.identites cascade;
     CREATE EXTENSION IF NOT EXISTS "unaccent";
 
-    CREATE COLLATION ignore_accents_case_insensitive (provider = icu, locale = 'und-u-ks-level1', deterministic = false);
-
     DROP EVENT TRIGGER pgrst_watch;
     CREATE OR REPLACE FUNCTION pgrst_watch() RETURNS event_trigger
       LANGUAGE plpgsql
@@ -58,20 +56,40 @@ data:
 
     CREATE OR REPLACE FUNCTION nom_officiel_q(identites)
     RETURNS text AS $$
+      SELECT (regexp_replace(UPPER($1.nom_officiel), '['',-]', ' ', 'g'));
+    $$ LANGUAGE SQL;
+
+    CREATE OR REPLACE FUNCTION nom_officiel_q_unaccent(identites)
+    RETURNS text AS $$
       SELECT (regexp_replace(UPPER(f_unaccent(($1.nom_officiel))), '['',-]', ' ', 'g'));
     $$ LANGUAGE SQL;
 
     CREATE OR REPLACE FUNCTION prenoms_officiels_q(identites)
     RETURNS text AS $$
-      SELECT (regexp_replace(($1.prenoms_officiels), '['',-]', ' ', 'g')) COLLATE ignore_accents_case_insensitive;
+      SELECT (regexp_replace(UPPER($1.prenoms_officiels), '['',-]', ' ', 'g'));
+    $$ LANGUAGE SQL;
+
+    CREATE OR REPLACE FUNCTION prenoms_officiels_q_unaccent(identites)
+    RETURNS text AS $$
+      SELECT (regexp_replace(UPPER(f_unaccent(($1.prenoms_officiels))), '['',-]', ' ', 'g'));
     $$ LANGUAGE SQL;
 
     CREATE OR REPLACE FUNCTION anc_nom_q(identites)
+    RETURNS text AS $$
+      SELECT (regexp_replace(UPPER($1.anc_nom), '['',-]', ' ', 'g'));
+    $$ LANGUAGE SQL;
+
+    CREATE OR REPLACE FUNCTION anc_nom_q_unaccent(identites)
     RETURNS text AS $$
       SELECT (regexp_replace(UPPER(f_unaccent(($1.anc_nom))), '['',-]', ' ', 'g'));
     $$ LANGUAGE SQL;
 
     CREATE OR REPLACE FUNCTION anc_prenoms_q(identites)
+    RETURNS text AS $$
+      SELECT (regexp_replace(UPPER($1.anc_prenoms), '['',-]', ' ', 'g'));
+    $$ LANGUAGE SQL;
+
+    CREATE OR REPLACE FUNCTION anc_prenoms_q_unaccent(identites)
     RETURNS text AS $$
       SELECT (regexp_replace(UPPER(f_unaccent(($1.anc_prenoms))), '['',-]', ' ', 'g'));
     $$ LANGUAGE SQL;


### PR DESCRIPTION
D'après Hassan: L'application consommatrice de l'API va nous envoyer des accents, e.g. la requête suivante doit retourner un résultat: `identites?prenoms_officiels_q=ilike.JEAN JACQUES ANDRÉ`

Modification des fonctions _q pour ne pas enlever les accents
Création des fonction _q_unaccent reprenant l'ancien code 